### PR TITLE
Fixing codemirror options

### DIFF
--- a/src/codemirror-editor.vue
+++ b/src/codemirror-editor.vue
@@ -93,7 +93,6 @@ const component = {
       matchBrackets: true,
       indentWithTabs: true,
       autoCloseBrackets: true,
-      ...this.codemirrorConfig,
       tabSize: this.tabSize,
       indentUnit: this.tabSize,
       value: this.text,
@@ -101,6 +100,7 @@ const component = {
       mode: 'markdown',
       lineWrapping: true,
       scrollbarStyle: 'overlay',
+      ...this.codemirrorConfig
     });
 
     this.codemirrorInstance.on('change', () => {


### PR DESCRIPTION
Currently, you cannot overwrite codemirror options like `mode` using props. To fix this, I have moved the props object to the bottom of the config object. This is because any options below the props object will be overwritten when merged. 