### PR TITLE
fix(style): arrow

### DIFF
--- a/src/assets/css/theme/vuepress-markdown.css
+++ b/src/assets/css/theme/vuepress-markdown.css
@@ -275,7 +275,11 @@
 .vuepress-markdown-body div[class~='v-md-pre-wrapper-php']::before {
   content: 'php';
 }
-.vuepress-markdown-body .arrow {
+.vuepress-markdown-body
+.arrow.up,
+.arrow.down,
+.arrow.left,
+.arrow.right {
   display: inline-block;
   width: 0;
   height: 0;


### PR DESCRIPTION
1. JavaScript arrow functions are displayed incorrectly：
![image](https://github.com/code-farmer-i/vue-markdown-editor/assets/32217093/f8ae75d5-b8a5-443e-a7b7-b7eed80e16b1)

2. Fixed：
<img width="568" alt="image" src="https://github.com/code-farmer-i/vue-markdown-editor/assets/32217093/518b6911-6aae-4763-8b5b-dd22205058ca">

3. The other arrows are also as expected：
<img width="574" alt="image" src="https://github.com/code-farmer-i/vue-markdown-editor/assets/32217093/78b6ab54-917e-4b17-84be-b9cf32c4226d">
<img width="576" alt="image" src="https://github.com/code-farmer-i/vue-markdown-editor/assets/32217093/fcc8d3a4-fc1a-43d3-9d1b-4553d0772173">
