### PR TITLE
fix(mixins/scroll): preview custom anchor scrolling

### DIFF
--- a/src/mixins/scroll.js
+++ b/src/mixins/scroll.js
@@ -8,7 +8,7 @@ export default {
         const previewScrollContainer = this.$refs.previewScroller.$el.querySelector(
           '.scrollbar__wrap'
         );
-        const defaultContainer = this.isPreviewMode ? window : previewScrollContainer;
+        const defaultContainer = this.isPreviewMode ? previewScrollContainer : window;
 
         return this.previewScrollContainer ? this.previewScrollContainer() : defaultContainer;
       };


### PR DESCRIPTION
修复Preview组件获取滚动容器错误导致在预览装下滚动不生效的问题